### PR TITLE
Team.confirmed_members property, to get only confirmed members

### DIFF
--- a/neighbourhood/admin.py
+++ b/neighbourhood/admin.py
@@ -24,7 +24,7 @@ class TeamMembershipInline(admin.TabularInline):
 
 @admin.register(Team)
 class TeamAdmin(OSMGeoAdmin):
-    list_display = ("name", "base_pc", "members_count", "status")
+    list_display = ("name", "base_pc", "members_count", "confirmed_members_count", "status")
     inlines = [
         TeamMembershipInline,
     ]
@@ -32,6 +32,10 @@ class TeamAdmin(OSMGeoAdmin):
     @admin.display(description="Members")
     def members_count(self, obj):
         return obj.members.count()
+
+    @admin.display(description="Confirmed members")
+    def confirmed_members_count(self, obj):
+        return obj.confirmed_members.count()
 
 
 class UserCreationForm(forms.ModelForm):

--- a/neighbourhood/models.py
+++ b/neighbourhood/models.py
@@ -99,6 +99,7 @@ class Team(models.Model):
     confirmed = models.BooleanField(default=False)
     status = models.CharField(max_length=300, blank=True, null=True)
 
+    # BEWARE! This includes unconfirmed applicants and rejected members!
     members = models.ManyToManyField(
         User, related_name="teams", related_query_name="team", through="Membership"
     )
@@ -106,8 +107,9 @@ class Team(models.Model):
     def __str__(self):
         return self.name
 
-    def members_count(self):
-        return self.members.count()
+    @property
+    def confirmed_members(self):
+        return self.members.filter(membership__confirmed=True)
 
     def vicinity(self):
         return self.address_3 if self.address_3 else self.address_2

--- a/neighbourhood/templates/neighbourhood/includes/search_result.html
+++ b/neighbourhood/templates/neighbourhood/includes/search_result.html
@@ -1,10 +1,10 @@
 <div class="p-3 p-md-4 bg-white border rounded d-block mb-3 mb-md-4 position-relative">
     <h2 class="mb-4"><a href="{% url 'team' team.slug %}" class="stretched-link">{{ team.name }}</a></h2>
     <div class="mb-3 d-flex align-items-center">
-      {% for member in team.members.all %}
+      {% for member in team.confirmed_members.all %}
         <img src="{{ member.avatar_url|escape }}" width="24" height="24" class="rounded-circle bg-primary me-n2" alt="" role="presentation" style="border: 2px solid #fff;">
       {% endfor %}
-        <p class="fw-bold mb-0 ms-3">{{ team.members_count }} {{ team.members_count|pluralize:"member,members" }}</p>
+        <p class="fw-bold mb-0 ms-3">{{ team.confirmed_members|length }} {{ team.confirmed_members|pluralize:"member,members" }}</p>
     </div>
     <p class="mb-2"><strong>Challenge:</strong> {{ team.challenge|default:"Understand your home" }}</p>
     <p class="mb-3"><strong>Currently:</strong> {{ team.status }}</p>

--- a/neighbourhood/templates/neighbourhood/team_private.html
+++ b/neighbourhood/templates/neighbourhood/team_private.html
@@ -8,10 +8,10 @@
             <p class="text-muted">A Neighbourhood Warmth team in {{ team.vicinity }}</p>
 
             <div class="my-4 d-flex align-items-center">
-              {% for member in team.members.all %}
+              {% for member in team.confirmed_members.all %}
                 <img src="{{ member.avatar_url|escape }}" width="32" height="32" class="rounded-circle bg-primary me-n2" alt="" role="presentation" style="border: 2px solid #fff;">
               {% endfor %}
-                <p class="h5 lh-sm mb-0 ms-3">{{ team.members_count }} {{ team.members_count|pluralize:"member,members" }}</p>
+                <p class="h5 lh-sm mb-0 ms-3">{{ team.confirmed_members|length }} {{ team.confirmed_members|pluralize:"member,members" }}</p>
             </div>
 
             <div>

--- a/neighbourhood/templates/neighbourhood/team_public.html
+++ b/neighbourhood/templates/neighbourhood/team_public.html
@@ -8,10 +8,10 @@
             <p class="text-muted">A Neighbourhood Warmth team in {{ team.vicinity }}</p>
 
             <div class="my-4 d-flex align-items-center">
-              {% for member in team.members.all %}
+              {% for member in team.confirmed_members.all %}
                 <img src="{{ member.avatar_url|escape }}" width="32" height="32" class="rounded-circle bg-primary me-n2" alt="" role="presentation" style="border: 2px solid #fff;">
               {% endfor %}
-                <p class="h4 lh-sm mb-0 ms-3">{{ team.members_count }} {{ team.members_count|pluralize:"member,members" }}</p>
+                <p class="h4 lh-sm mb-0 ms-3">{{ team.confirmed_members|length }} {{ team.confirmed_members|pluralize:"member,members" }}</p>
             </div>
 
             <p class="h4 mb-5 mw-40rem">Hello! We are currently {{ team.status }}.</p>


### PR DESCRIPTION
Fixes a bug throughout the site, where team member counts were including unconfirmed / rejected memberships.